### PR TITLE
fix: updating deploy.yml, creating unified logic for repo owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,13 @@ name: CI-CD Pipeline
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
-    branches:
-      - master
+    branches: [master]
   workflow_dispatch:
 
+env:
+  IMAGE_OWNER: ${{ github.repository_owner }}
 
 jobs:
   build-and-test:
@@ -16,6 +16,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('src/requirements/dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -33,7 +41,7 @@ jobs:
 #      - name: Run Flake8
 #        run: flake8 ./src
 
-      # todo: add Unittests and django tests
+      # todo: Add django tests
 
   build-and-push:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -46,42 +54,50 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Set image owner
-        run: echo "IMAGE_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+      - name: Normalize image owner
+        run: echo "IMAGE_OWNER=$(echo '${{ env.IMAGE_OWNER }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Tag Backend Image
+      - name: Build & tag backend
         run: |
-          BACKEND_IMAGE=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-backend
-          docker build -t $BACKEND_IMAGE:latest -f ./src/Dockerfile ./src
-          docker tag $BACKEND_IMAGE:latest $BACKEND_IMAGE:${{ github.run_number }}
+          BACK=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-backend
+          docker build \
+            --cache-from=type=registry,ref=${BACK}:cache \
+            --cache-to=type=registry,ref=${BACK}:cache,mode=max \
+            -t ${BACK}:latest -f ./src/Dockerfile ./src
+          docker tag ${BACK}:latest ${BACK}:${{ github.run_number }}
 
-      - name: Push Backend Image
+      - name: Push backend
         run: |
-          BACKEND_IMAGE=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-backend
-          docker push $BACKEND_IMAGE:latest
-          docker push $BACKEND_IMAGE:${{ github.run_number }}
+          BACK=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-backend
+          docker push ${BACK}:latest
+          docker push ${BACK}:cache
+          docker push ${BACK}:${{ github.run_number }}
 
-      - name: Build and Tag Frontend Image
+      - name: Build & tag frontend
         run: |
-          FRONTEND_IMAGE=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-frontend
-          docker build -t $FRONTEND_IMAGE:latest -f ./frontend/Dockerfile ./frontend
-          docker tag $FRONTEND_IMAGE:latest $FRONTEND_IMAGE:${{ github.run_number }}
+          FRONT=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-frontend
+          docker build \
+            --cache-from=type=registry,ref=${FRONT}:cache \
+            --cache-to=type=registry,ref=${FRONT}:cache,mode=max \
+            -t ${FRONT}:latest -f ./frontend/Dockerfile ./frontend
+          docker tag ${FRONT}:latest ${FRONT}:${{ github.run_number }}
 
-      - name: Push Frontend Image
+      - name: Push frontend
         run: |
-          FRONTEND_IMAGE=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-frontend
-          docker push $FRONTEND_IMAGE:latest
-          docker push $FRONTEND_IMAGE:${{ github.run_number }}
+          FRONT=ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-frontend
+          docker push ${FRONT}:latest
+          docker push ${FRONT}:cache
+          docker push ${FRONT}:${{ github.run_number }}
 
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -91,23 +107,42 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-
-      - name: Set image owner
-        run: echo "IMAGE_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+      - name: Normalize image owner
+        run: echo "IMAGE_OWNER=$(echo '${{ env.IMAGE_OWNER }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Render stack file
         run: envsubst < stack.yml > stack_rendered.yml
 
-      - name: Upload stack file via scp
-        uses: appleboy/scp-action@v0.1.6
+      - name: Ensure remote directory exists
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          script: |
+            mkdir -p /home/${{ secrets.VDS_USER }}/perekhodnichki
+
+      - name: Upload via SCP
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.VDS_HOST }}
           username: ${{ secrets.VDS_USER }}
           key: ${{ secrets.VDS_SSH_KEY }}
           source: "./stack_rendered.yml"
-          target: "/home/${{ secrets.VDS_USER }}/perekhodnichki/stack.yml"
+          target: "/home/${{ secrets.VDS_USER }}/perekhodnichki"
           overwrite: true
           strip_components: 0
+          debug: true
+
+      - name: Rename to stack.yml on remote
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.VDS_HOST }}
+          username: ${{ secrets.VDS_USER }}
+          key: ${{ secrets.VDS_SSH_KEY }}
+          script: |
+            mv /home/${{ secrets.VDS_USER }}/perekhodnichki/stack_rendered.yml \
+               /home/${{ secrets.VDS_USER }}/perekhodnichki/stack.yml
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v0.1.7
@@ -116,9 +151,10 @@ jobs:
           username: ${{ secrets.VDS_USER }}
           key: ${{ secrets.VDS_SSH_KEY }}
           script: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
+            echo "${{ secrets.GITHUB_TOKEN }}" \
+              | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker pull ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-backend:latest
             docker pull ghcr.io/${{ env.IMAGE_OWNER }}/perekhodnichki-frontend:latest
-
-            docker stack deploy -c /home/${{ secrets.VDS_USER }}/perekhodnichki/stack.yml perekhodnichki
+            docker stack deploy \
+              -c /home/${{ secrets.VDS_USER }}/perekhodnichki/stack.yml \
+              perekhodnichki


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configuration in `.github/workflows/deploy.yml` to improve efficiency, maintainability, and clarity. Key changes include caching dependencies, refactoring image-building steps, and enhancing deployment processes.

### CI/CD Pipeline Improvements:

* Added a `Cache pip` step to reuse cached dependencies for Python, reducing build times. (`[.github/workflows/deploy.ymlR20-R27](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R20-R27)`)
* Normalized the `IMAGE_OWNER` environment variable by utilizing the global `env` block, simplifying its usage across jobs. (`[[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L5-R11)`, `[[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L49-R100)`, `[[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L94-R160)`)

### Docker Image Building Enhancements:

* Refactored backend and frontend image-building steps to include build cache support, improving build efficiency. (`[.github/workflows/deploy.ymlL49-R100](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L49-R100)`)
* Renamed steps for better readability (e.g., "Build & tag backend" instead of "Build and Tag Backend Image"). (`[.github/workflows/deploy.ymlL49-R100](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L49-R100)`)

### Deployment Process Enhancements:

* Added a step to ensure the remote directory exists before uploading files, preventing potential errors. (`[.github/workflows/deploy.ymlL94-R160](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L94-R160)`)
* Improved deployment clarity by separating file upload and renaming steps, and added debugging options for SCP uploads. (`[.github/workflows/deploy.ymlL94-R160](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L94-R160)`)